### PR TITLE
Initially added documentation.

### DIFF
--- a/sake/__init__.py
+++ b/sake/__init__.py
@@ -4,7 +4,7 @@ __all__: typing.Final[typing.Sequence[str]] = []
 
 import typing
 
-from . import traits
-from .cache import *
-from .errors import *
-from .views import *
+from sake import traits
+from sake.cache import *
+from sake.errors import *
+from sake.views import *

--- a/sake/__init__.py
+++ b/sake/__init__.py
@@ -4,7 +4,7 @@ __all__: typing.Final[typing.Sequence[str]] = []
 
 import typing
 
-from sake import traits
-from sake.cache import *
-from sake.errors import *
-from sake.views import *
+from . import traits
+from .cache import *
+from .errors import *
+from .views import *

--- a/sake/conversion.py
+++ b/sake/conversion.py
@@ -108,7 +108,7 @@ def deserialize_guild(data: typing.Mapping[str, str], *, app: traits.RESTAware) 
         premium_tier=guilds.GuildPremiumTier(int(data["premium_tier"])),
         preferred_locale=data["preferred_locale"],
         verification_level=guilds.GuildVerificationLevel(int(data["verification_level"])),
-        system_channel_flags=snowflakes.Snowflake(data["system_channel_flags"]),
+        system_channel_flags=guilds.GuildSystemChannelFlag(data["system_channel_flags"]),
         icon_hash=data.get("icon_hash"),
         splash_hash=data.get("splash_hash"),
         discovery_splash_hash=data.get("discovery_splash_hash"),

--- a/sake/errors.py
+++ b/sake/errors.py
@@ -1,17 +1,36 @@
 from __future__ import annotations
 
-__all__: typing.Final[typing.Sequence[str]] = ["SakeException", "NotFound", "KeptAliveByReference"]
+__all__: typing.Final[typing.Sequence[str]] = [
+    "SakeException",
+]
 
 import typing
 
 
 class SakeException(Exception):
+    """A base exception for the expected exceptions raised by Sake implementations."""
+
+    __slots__: typing.Sequence[str] = ("base_exception", "message")
+
+    message: str
+    base: typing.Optional[BaseException]
+
+    def __init__(self, message: str, *, exception: typing.Optional[BaseException] = None) -> None:
+        self.message = message
+        self.base_exception = exception
+
+
+class InvalidDataFound(SakeException, LookupError):
     __slots__: typing.Sequence[str] = ()
 
 
-class NotFound(SakeException, LookupError):
+class InvalidStructureFound(SakeException, LookupError):
     __slots__: typing.Sequence[str] = ()
 
 
-class KeptAliveByReference(NotFound, ValueError):
+class KeptAliveByReference(SakeException, ValueError):
+    __slots__: typing.Sequence[str] = ()
+
+
+class EntryNotFound(SakeException, LookupError):
     __slots__: typing.Sequence[str] = ()

--- a/sake/traits.py
+++ b/sake/traits.py
@@ -280,8 +280,8 @@ class UserCache(Resource, typing.Protocol):  # TODO: add this to more classes?
 
     __slots__: typing.Sequence[str] = ()
 
-    # async def delete_user(self) -> None:
-    #     raise NotImplementedError
+    async def delete_user(self, user_id: snowflakes.Snowflakeish) -> None:
+        raise NotImplementedError
 
     async def get_user(self, user_id: snowflakes.Snowflakeish) -> users.User:
         raise NotImplementedError
@@ -289,8 +289,8 @@ class UserCache(Resource, typing.Protocol):  # TODO: add this to more classes?
     async def get_user_view(self) -> views.CacheView[snowflakes.Snowflake, users.User]:
         raise NotImplementedError
 
-    # async def set_user(self, user: users.User) -> None:
-    #     raise NotImplementedError
+    async def set_user(self, user: users.User) -> None:
+        raise NotImplementedError
 
 
 class VoiceStateCache(Resource, typing.Protocol):

--- a/sake/traits.py
+++ b/sake/traits.py
@@ -1,7 +1,8 @@
+"""Traits for the cache resources defined by this standard."""
+
 from __future__ import annotations
 
 __all__: typing.Final[typing.Sequence[str]] = [
-    "RESTAndDispatcherAware",
     "Resource",
     "EmojiCache",
     "GuildCache",
@@ -17,43 +18,59 @@ __all__: typing.Final[typing.Sequence[str]] = [
 
 import typing
 
-from hikari import traits as _traits
-
 if typing.TYPE_CHECKING:
-    import aioredis
     from hikari import channels
     from hikari import emojis
     from hikari import guilds
     from hikari import invites
     from hikari import presences
     from hikari import snowflakes
+    from hikari import traits as _traits
     from hikari import users
     from hikari import voices
 
-    from sake import views
-
-
-class RESTAndDispatcherAware(_traits.DispatcherAware, _traits.RESTAware, typing.Protocol):
-    ...
+    from . import views
 
 
 class Resource(typing.Protocol):
+    """The basic interface which all cache resources should implement."""
+
     __slots__: typing.Sequence[str] = ()
 
-    @property
-    def app(self) -> RESTAndDispatcherAware:
+    def subscribe_listener(self, app: _traits.DispatcherAware) -> None:
+        """Register this resource's internal listener to a dispatcher aware app.
+
+        !!! note
+            Dependent on the implementation, this may be called by
+            `Resource.open` and may raise a `builtins.TypeError`if called
+            when this resource's listeners have already been registered.
+        """
         raise NotImplementedError
 
-    def subscribe_listener(self) -> None:
-        raise NotImplementedError
+    def unsubscribe_listener(self, app: _traits.DispatcherAware) -> None:
+        """Unregister this resource's internal listener to a dispatcher aware app.
 
-    def unsubscribe_listener(self) -> None:
+        !!! note
+            Dependent on the implementation, this may be called by
+            `Resource.close` and may raise a `builtins.TypeError`if called
+            when this resource's listeners haven't been registered yet.
+        """
         raise NotImplementedError
 
     async def open(self) -> None:
-        raise NotImplementedError
+        """Startup the resource(s) and allow them to connect to their relevant backend.
+
+        !!! note
+            This may call `Resource.subscribe_listener` in some implementations.
+
+        !!! note
+            This should pass without raising if called on an already opened
+            resource.
+        """
+        raise NotImplementedError  # TODO: connection errors.
 
     async def close(self) -> None:
+        """"""
         raise NotImplementedError
 
 
@@ -64,7 +81,7 @@ class EmojiCache(Resource, typing.Protocol):
         raise NotImplementedError
 
     async def clear_emojis_for_guild(self, guild_id: snowflakes.Snowflakeish) -> None:
-        ...
+        raise NotImplementedError
 
     async def delete_emoji(self, emoji_id: snowflakes.Snowflakeish) -> None:
         raise NotImplementedError

--- a/sake/traits.py
+++ b/sake/traits.py
@@ -29,7 +29,7 @@ if typing.TYPE_CHECKING:
     from hikari import users
     from hikari import voices
 
-    from . import views
+    from sake import views
 
 
 class Resource(typing.Protocol):
@@ -37,31 +37,39 @@ class Resource(typing.Protocol):
 
     __slots__: typing.Sequence[str] = ()
 
-    def subscribe_listener(self, app: _traits.DispatcherAware) -> None:
+    def subscribe_listeners(self) -> None:
         """Register this resource's internal listener to a dispatcher aware app.
 
         !!! note
             Dependent on the implementation, this may be called by
             `Resource.open` and may raise a `builtins.TypeError`if called
             when this resource's listeners have already been registered.
+
+        !!! note
+            If the event dispatcher isn't provided during initialisation then
+            this method will do nothing.
         """
         raise NotImplementedError
 
-    def unsubscribe_listener(self, app: _traits.DispatcherAware) -> None:
+    def unsubscribe_listeners(self) -> None:
         """Unregister this resource's internal listener to a dispatcher aware app.
 
         !!! note
             Dependent on the implementation, this may be called by
             `Resource.close` and may raise a `builtins.TypeError`if called
             when this resource's listeners haven't been registered yet.
+
+        !!! note
+            If the event dispatcher isn't provided during initialisation then
+            this method will do nothing.
         """
         raise NotImplementedError
 
     async def open(self) -> None:
-        """Startup the resource(s) and allow them to connect to their relevant backend.
+        """Startup the resource(s) and allow them to connect to their relevant backend(s).
 
         !!! note
-            This may call `Resource.subscribe_listener` in some implementations.
+            This should implicitly call `Resource.subscribe_listeners`.
 
         !!! note
             This should pass without raising if called on an already opened
@@ -70,7 +78,15 @@ class Resource(typing.Protocol):
         raise NotImplementedError  # TODO: connection errors.
 
     async def close(self) -> None:
-        """"""
+        """Close the resource(s) and allow them to disconnect from their relevant backend(s).
+
+        !!! note
+            This should implicitly call `Resource.unsubscribe_listeners`.
+
+        !!! note
+            This should pass without raising if called on an already closed
+            resource.
+        """
         raise NotImplementedError
 
 


### PR DESCRIPTION
* split out ResourceClient.app into `.dispatcher` and `.rest`.
* Shuffle out and added errors.
* Switch to relative imports for internal imports.