### PR TITLE
bug: fix python version typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hikari-sake"
 version = "1.0.1a1"
 description = "Asynchronous cache framework (with standard Redis impl) for Hikari."
 readme = "README.md"
-requires-python = ">>=3.8.0,<3.12"
+requires-python = ">=3.8.0,<3.12"
 license = {file = "LICENSE"}
 authors = [ {name = "Faster Speeding", email="lucina@lmbyrne.dev"} ]
 keywords= ["hikari"]


### PR DESCRIPTION
Python version consisted of an extra `>` symbol which lead to failure of parsing the version constraint.