### PR TITLE
Isinstance behaviour changed for Protocols in Py => v3.12

### DIFF
--- a/sake/_internal.py
+++ b/sake/_internal.py
@@ -46,6 +46,7 @@ import inspect
 import math
 import typing
 from collections import abc as collections
+from hikari.internal import fast_protocol
 
 import hikari
 
@@ -87,7 +88,7 @@ def convert_expire_time(expire: ExpireT, /) -> typing.Optional[int]:
 
 
 @typing.runtime_checkable
-class ListenerProto(typing.Protocol[_EventT_inv]):
+class ListenerProto(fast_protocol.FastProtocolChecking, typing.Protocol[_EventT_inv]):
     """Protocol of an event listener method."""
 
     async def __call__(self, event: _EventT_inv, /) -> None:
@@ -107,7 +108,7 @@ class ListenerProto(typing.Protocol[_EventT_inv]):
 
 
 @typing.runtime_checkable
-class RawListenerProto(typing.Protocol):
+class RawListenerProto(fast_protocol.FastProtocolChecking, typing.Protocol):
     """Protocol of a raw event listener method."""
 
     async def __call__(self, event: hikari.ShardPayloadEvent, /) -> None:


### PR DESCRIPTION
### Summary
As described [here](https://discord.com/channels/574921006817476608/1127998250587258880/1305999460786114632) the behaviour of isinstance changed for python 3.12 or newer which broke the listener functionallity.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
